### PR TITLE
Cap MONAI below 1.6 due to broken dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "nibabel == 5.*",
     "torch == 2.*",
     "tqdm",
-    "monai == 1.*",
+    "monai >=1,<1.6",
     "huggingface_hub",
     "scikit-image",
     "pandas"


### PR DESCRIPTION
A fresh install currently resolves MONAI to the latest 1.x.  As of MONAI 1.6.0 "monai.transforms.compose" no longer re-exports "MapTransform", which mindGlide imports at startup:

Fix (pyproject.toml)

    -    "monai == 1.*",
    +    "monai >=1,<1.6",

Alternative (not tested, File ".../inference/mindglide/transforms.py", line 15, in <module>)
MONAI 1.6+ could be supported instead by updating the import, since "MapTransform" is still available:

    - from monai.transforms.compose import MapTransform
    + from monai.transforms import MapTransform