### PR TITLE
Fix MapTransform import for MONAI 1.6+ compatibility

### DIFF
--- a/inference/mindglide/transforms.py
+++ b/inference/mindglide/transforms.py
@@ -12,7 +12,7 @@ from monai.transforms import (
     EnsureTyped,
     Orientationd
 )
-from monai.transforms.compose import MapTransform
+from monai.transforms import MapTransform
 from monai.transforms.utils import generate_spatial_bounding_box
 from skimage.transform import resize
 from scipy import ndimage


### PR DESCRIPTION
MONAI 1.6.0 stopped re-exporting `MapTransform` from `monai.transforms.compose`, which breaks mindGlide at import time on fresh installs (reported in #48).

Rather than capping the dependency, this imports `MapTransform` from the `monai.transforms` public API, as suggested by @danesedQSA in #48. Verified against MONAI source that this import path works at both ends of the allowed range (1.0.0 and 1.6.0), and that every other MONAI symbol mindGlide uses (`generate_spatial_bounding_box`, `DynUNet`, `SlidingWindowInferer`, and all transforms) still exists in 1.6.0 — so `monai == 1.*` can stay uncapped.

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)