### PR TITLE
Friendlier CLI, robust error handling, tests, and quickstart docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,23 @@
-# Use the official PyTorch 2.9.1 image with CUDA 12.8 (cu128)
+# Official PyTorch image with CUDA runtime (also works on CPU-only hosts)
 FROM pytorch/pytorch:2.9.1-cuda12.8-cudnn9-runtime
 
-# Set working directory
 WORKDIR /workspace
 
-# Install any system dependencies your project needs
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        build-essential \
-        git \
         wget \
         ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# (Optional) If you need a specific Python version or virtualenv:
-# For example, ensure python3.11 is available:
-# RUN apt-get update && apt-get install -y python3.11 python3.11-dev python3.11-distutils \
-#     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
-
-# Install pip packages
-# Make sure the torch version corresponds to your base image – 
-# here it’s already installed via the base image, but you might reinstall/upgrade other libs.
 COPY . /workspace/
 RUN pip install --no-cache-dir .
-    
+
+# Bake the model weights into the image so the container works offline
 RUN mkdir -p /workspace/models && \
-    wget -O /workspace/models/_20240404_conjurer_trained_dice_7733.pt \
+    wget -q -O /workspace/models/_20240404_conjurer_trained_dice_7733.pt \
         https://huggingface.co/MS-PINPOINT/mindglide/resolve/main/_20240404_conjurer_trained_dice_7733.pt
+
 ENV PYTHONUNBUFFERED=1 \
-    # any other environment variables your app needs \
-    CUDA_LAUNCH_BLOCKING=1 \
     MODEL_PATH="/workspace/models/_20240404_conjurer_trained_dice_7733.pt"
 
+ENTRYPOINT ["mindglide"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # MindGlide
 
 <p>
-<strong>Ultrafast segmentation of real‑world brain MRI for multiple‑sclerosis patients — any modality, any quality.</strong><br>Built with PyTorch + MONAI and trained on >23 000 scans.<br>
+<strong>Ultrafast segmentation of real‑world brain MRI for multiple‑sclerosis patients — any modality, any quality.</strong><br>Built with PyTorch + MONAI and trained on >23 000 scans.<br>
 </p>
 
 <p align="center">
@@ -12,34 +12,74 @@
 </div>
 
 
+## Quickstart
+
+Requirements: Python ≥ 3.9 and `pip`. A GPU is **not** required — MindGlide
+runs in seconds on a GPU and typically in a few minutes per scan on a CPU.
+
+```bash
+# 1) install (in a virtual environment if you prefer)
+pip install git+https://github.com/MS-PINPOINT/mindGlide.git
+
+# 2) check the command is available
+mindglide --help
+
+# 3) segment a scan
+mindglide -i /path/to/scan.nii.gz -o /path/to/scan_seg.nii.gz
+```
+
+The first run downloads the trained model (~123 MB) automatically from the
+[Hugging Face Hub](https://huggingface.co/MS-PINPOINT/mindglide) and caches it,
+so later runs work offline.
+
+No scan at hand? Try it on the public MNI152 template:
+
+```bash
+curl -O https://templateflow.s3.amazonaws.com/tpl-MNI152NLin2009cAsym/tpl-MNI152NLin2009cAsym_res-01_T1w.nii.gz
+mindglide -i tpl-MNI152NLin2009cAsym_res-01_T1w.nii.gz -o mni_seg.nii.gz
+```
+
+Open the result on top of the input in your favourite viewer (FSLeyes, ITK-SNAP,
+freeview…) to inspect the 19 segmented regions.
+
+
 ## Usage
 
-You can install the tool directly from the GitHub repository using `pip`:
+Segment a single scan:
 
 ```bash
-pip install git+https://github.com/MS-PINPOINT/mindGlide.git
+mindglide -i scan.nii.gz -o scan_seg.nii.gz
 ```
 
-After installation, verify that the command is available by running:
+Segment every NIfTI file in a directory (the model is loaded once; outputs are
+named `<scan>_seg.nii.gz`; non-NIfTI files are ignored):
 
 ```bash
-mindglide --help
+mindglide -i scans_dir/ -o segmentations_dir/
+# add --resume to skip scans already segmented in the output directory
 ```
 
-To segment a scan, run:
+Useful options:
+
+| Option | Meaning |
+|---|---|
+| `--device {auto,cpu,cuda,mps}` | Compute device. Default `auto` picks a working GPU if present, else CPU. |
+| `--sw-batch-size N` | Sliding-window batch size (default 4). Lower it if you run out of GPU memory. |
+| `--model-path FILE` | Use a local `.pt` checkpoint instead of the automatic download (useful offline). |
+| `--resume` | Directory mode: skip scans already segmented. |
+| `--no-klc` | Keep all connected components (skip largest-component cleanup). |
+| `--no-reorient` | Skip internal RAS re-orientation. Output always matches the input scan's grid. |
+| `--version` | Print the installed version. |
+
+### Per-region volumes
+
+Turn a segmentation into a CSV of region volumes (mm³):
 
 ```bash
-mindglide -i /path/to/input.nii.gz -o /path/to/output.nii.gz
+mindglide-volumes scan_seg.nii.gz --out-csv scan_volumes.csv
 ```
 
-You can adjust the `--sw_batch_size` parameter (default: 4) based on your available VRAM.
-MindGlide runs in seconds on a GPU, and typically in under 3 minutes on a CPU.
-Device selection (GPU or CPU) is handled automatically.
-
-The `mindglide` command also supports directories of NIfTI files as input, allowing you to process multiple scans at once without reloading the model each time.
-
-The following table maps the segmentation codes to their corresponding region names:
-
+### Label map
 
 | Code | Structure Name                  | Code | Structure Name           |
 |:----:|:--------------------------------|:----:|:--------------------------|
@@ -55,83 +95,112 @@ The following table maps the segmentation codes to their corresponding region na
 | 9    | Lateral_ventricle               | 19   | Ventral_diencephalon      |
 
 
+## Troubleshooting
 
-
-
-## Run from scripts
-
-### Requirements
-- Git ≥ 2.13
-- IMPORTANT: Git LFS — one‑time setup: `git lfs install`
-- Docker
-- *(Optional)* Apptainer/Singularity for HPC environments
-
-### Clone & get the pretrained checkpoint
+**"Warning: not using the GPU — … this PyTorch build cannot run on it"** —
+the default `pip` PyTorch wheels no longer ship kernels for older GPU
+architectures (e.g. Pascal cards: GTX 10xx, Quadro P series). MindGlide falls
+back to CPU automatically. To use such a GPU, install a PyTorch build with an
+older CUDA variant first, then install MindGlide:
 
 ```bash
-# 1) clone the code **and** the models sub‑repo in one step
+pip install "torch==2.6.0+cu118" --index-url https://download.pytorch.org/whl/cu118
+pip install git+https://github.com/MS-PINPOINT/mindGlide.git
+```
+
+**GPU out of memory** — lower the sliding-window batch size
+(`--sw-batch-size 1`) or run with `--device cpu`.
+
+**Apple Silicon (M-series)** — `auto` uses MPS when available. If you hit an
+unsupported-operation error, run with `--device cpu` or set
+`PYTORCH_ENABLE_MPS_FALLBACK=1`.
+
+**Offline / air-gapped machines** — download
+[`_20240404_conjurer_trained_dice_7733.pt`](https://huggingface.co/MS-PINPOINT/mindglide/tree/main)
+once and pass it with `--model-path /path/to/model.pt` (or set the
+`MODEL_PATH` environment variable).
+
+
+## Run in Docker
+
+Build the image once (bakes in the model weights, so the container runs
+offline):
+
+```bash
+git clone https://github.com/MS-PINPOINT/mindGlide.git
+cd mindGlide
+docker build -t mindglide .
+```
+
+Then segment scans in a mounted folder:
+
+```bash
+# with a GPU
+docker run --gpus all --ipc=host -v /data:/data \
+  mindglide -i /data/scan.nii.gz -o /data/scan_seg.nii.gz
+
+# CPU only
+docker run --ipc=host -v /data:/data \
+  mindglide -i /data/scan.nii.gz -o /data/scan_seg.nii.gz
+```
+
+For Singularity/Apptainer on HPC, build from the same image:
+
+```bash
+apptainer build mindglide.sif docker-daemon://mindglide:latest
+apptainer run --nv -B /data:/data mindglide.sif -i /data/scan.nii.gz -o /data/scan_seg.nii.gz
+```
+
+
+## Model weights
+
+The primary checkpoint is downloaded automatically on first run and lives at
+[Hugging Face: MS-PINPOINT/mindglide](https://huggingface.co/MS-PINPOINT/mindglide)
+(`_20240404_conjurer_trained_dice_7733.pt`). Additional or legacy checkpoints
+are archived in the same repository. The models were trained on the datasets
+described in the paper
+[**Nature Communications (2025)**](https://www.nature.com/articles/s41467-025-58274-8#citeas).
+
+If you work from a source checkout, you can also fetch the weights as a git
+submodule (requires [Git LFS](https://git-lfs.com)):
+
+```bash
 git clone --recurse-submodules https://github.com/MS-PINPOINT/mindGlide.git
 cd mindGlide
-
-# 2) first‑time only – install Git‑LFS on your machine
-#    macOS:  brew install git-lfs
-#    Linux:  sudo apt install git-lfs
-git lfs install
-
-# 3) pull the large model file inside the submodule
+git lfs install            # first time only
 git submodule foreach 'git lfs pull'
+```
 
-
-If you already cloned without the flag:
+If you already cloned without `--recurse-submodules`:
 
 ```bash
 git submodule update --init --recursive
 ```
 
-This pulls the model repo from the Hugging Face Hub and places
-`models/_20240404_conjurer_trained_dice_7733.pt` in the workspace.
-
-PyTorch trained models are stored on Huggingface:
-`https://huggingface.co/MS-PINPOINT/mindglide/tree/main`
-
-Trained models are shared in the `models` directory.
-They are trained on the datasets explained in the paper [**Nature Communications (2025)**](https://www.nature.com/articles/s41467-025-58274-8#citeas).
+This places `models/_20240404_conjurer_trained_dice_7733.pt` in the workspace.
 
 
-## Run in Docker (GPU)
+## Development and tests
 
 ```bash
-docker run --gpus all \
-  --ipc=host --ulimit memlock=-1 -it \
-  -v /data:/data \
-  <Mindglide image> -i /data/<your_scan>.nii.gz -o /data/output.nii.gz
+git clone https://github.com/MS-PINPOINT/mindGlide.git
+cd mindGlide
+pip install -e ".[test]"
 
+# fast unit tests (no model download, a few seconds)
+pytest
+
+# full end-to-end tests: download the model and segment a public MNI template
+# on CPU — and on GPU when one is available
+MINDGLIDE_RUN_SLOW=1 pytest -v
 ```
 
-For Singularity/Apptainer, build once then run:
-
-```bash
-singularity run --nv \
-  --bind $PWD:/mnt \
-  /path/to/mind-glide_latest.sif <your_scan>.nii.gz
-```
 
 ## Fine‑tuning
 
 Use the scripts in `scripts/` as a template. Start with a low learning
-rate (e.g. 1e‑3) to avoid catastrophic forgetting — shipped models were
-trained with 1e‑2.
-
-
-## Model weights
-
-The primary checkpoint lives in this repo at:
-
-```
-models/_20240404_conjurer_trained_dice_7733.pt
-```
-
-Additional or legacy checkpoints are archived in the [Hugging Face model repo](https://huggingface.co/MS-PINPOINT/mindglide).
+rate (e.g. 1e‑3) to avoid catastrophic forgetting — shipped models were
+trained with 1e‑2.
 
 
 ### 📬 Citation
@@ -160,7 +229,7 @@ If you use MindGlide please cite this paper:
 ## Acknowledgements
 
 This study/project is funded by the UK National Institute for Health and
-Social Care (NIHR) Advanced Fellowship to Arman Eshaghi (Award ID:
+Social Care (NIHR) Advanced Fellowship to Arman Eshaghi (Award ID:
 NIHR302495). The views expressed are those of the author(s) and not
 necessarily those of the NIHR or the Department of Health and Social
 Care.
@@ -168,4 +237,3 @@ Care.
 <p align="left">
   <img src="assets/nihr_logo.png" alt="NIHR logo" width="200">
 </p>
-

--- a/inference/mindglide/infer.py
+++ b/inference/mindglide/infer.py
@@ -1,98 +1,314 @@
 import os
+import sys
 import argparse
 import warnings
 from pathlib import Path
 warnings.filterwarnings("ignore")
 
+CITATION = """
+If you use this tool, please cite the original MindGlide paper:
+------
+Goebl, P., Wingrove, J., Abdelmannan, O., Brito Vega, B., Stutters,
+J., Ramos, S. D. G., ... & Eshaghi, A. (2025).
+Enabling new insights from old scans by repurposing clinical MRI archives for multiple sclerosis research.
+Nature Communications, 16(1), 3149.
+------
+"""
 
-def get_best_device():
+HF_REPO_ID = "MS-PINPOINT/mindglide"
+HF_MODEL_FILENAME = "_20240404_conjurer_trained_dice_7733.pt"
+
+NIFTI_SUFFIXES = ('.nii', '.nii.gz')
+
+
+def get_version():
+    try:
+        from importlib.metadata import version
+        return version("mindglide")
+    except Exception:
+        return "unknown"
+
+
+def is_nifti(path):
+    return str(path).lower().endswith(NIFTI_SUFFIXES)
+
+
+def nifti_stem(filename):
+    """'sub-01_T1w.nii.gz' -> ('sub-01_T1w', 'nii.gz')"""
+    name = str(filename)
+    for suffix in NIFTI_SUFFIXES:
+        if name.lower().endswith(suffix):
+            return name[:-len(suffix)], suffix.lstrip('.')
+    return name, ''
+
+
+def cuda_is_usable():
     """
-    Select the best available device for computation.
-    Priority: CUDA (GPU) > MPS (Apple Silicon) > CPU.
+    True only if a CUDA device exists AND can actually run kernels.
+    torch.cuda.is_available() alone is not enough: pip's default PyTorch wheels
+    drop older GPU architectures (e.g. Pascal cards like the GTX 10xx / Quadro
+    P series with current cu12x wheels), in which case every kernel launch
+    fails with 'no kernel image is available' even though CUDA is 'available'.
     """
     import torch
-    if torch.cuda.is_available(): return torch.device("cuda")
-    if torch.mps.is_available():  return torch.device("mps")
-    return torch.device("cpu")
+    if not torch.cuda.is_available():
+        return False, "no CUDA GPU detected by PyTorch"
+    try:
+        (torch.zeros(1, device="cuda") + 1).item()
+        return True, None
+    except RuntimeError as e:
+        gpu = torch.cuda.get_device_name(0)
+        return False, (
+            f"your GPU ({gpu}) is detected but this PyTorch build cannot run on it.\n"
+            f"Underlying error: {str(e).splitlines()[0]}\n"
+            "This usually means the pre-built PyTorch wheels no longer include kernels\n"
+            "for your GPU's architecture. Install a PyTorch build that supports it\n"
+            "(see https://pytorch.org/get-started/locally/ — an older CUDA variant,\n"
+            "e.g. the cu118 wheels, often restores support for older GPUs)."
+        )
 
 
-def main():
+def resolve_device(choice="auto"):
     """
-    Runs the MindGlide model inference on a directory of NIfTI files.
+    Resolve the compute device. With "auto", pick the best available:
+    working CUDA (GPU) > MPS (Apple Silicon) > CPU.
     """
-    parser = argparse.ArgumentParser(description="MindGlide: Brain Segmentation Inference Tool")
+    import torch
 
+    def mps_available():
+        try:
+            return torch.backends.mps.is_available()
+        except AttributeError:
+            return False
+
+    if choice == "auto":
+        if torch.cuda.is_available():
+            usable, reason = cuda_is_usable()
+            if usable:
+                return torch.device("cuda")
+            print(f"Warning: not using the GPU — {reason}")
+            print("Falling back to CPU.\n")
+        if mps_available():
+            return torch.device("mps")
+        return torch.device("cpu")
+
+    if choice == "cuda":
+        usable, reason = cuda_is_usable()
+        if not usable:
+            sys.exit(f"Error: --device cuda requested but {reason}\n"
+                     "Run with --device cpu to use the CPU instead.")
+    if choice == "mps" and not mps_available():
+        sys.exit("Error: --device mps requested but MPS (Apple Silicon) is not available. "
+                 "Run with --device cpu instead.")
+    return torch.device(choice)
+
+
+def collect_io(inp, out, resume=False):
+    """
+    Validate input/output paths and return the list of (input, output) file
+    pairs to process. Exits with a clear message on user error.
+    """
+    inp, out = str(inp), str(out)
+
+    # --- single-file mode ---------------------------------------------------
+    if is_nifti(inp):
+        if not os.path.isfile(inp):
+            sys.exit(f"Error: input file not found: {inp}")
+        if os.path.isdir(out):
+            # allow "-i scan.nii.gz -o existing_dir/" for convenience
+            stem, ext = nifti_stem(os.path.basename(inp))
+            out = os.path.join(out, f"{stem}_seg.{ext}")
+        elif not is_nifti(out):
+            sys.exit(
+                f"Error: output path must end in .nii or .nii.gz (got: {out}).\n"
+                "Example: mindglide -i scan.nii.gz -o scan_seg.nii.gz"
+            )
+        parent = os.path.dirname(os.path.abspath(out))
+        try:
+            os.makedirs(parent, exist_ok=True)
+        except OSError as e:
+            sys.exit(f"Error: cannot create output directory {parent}: {e}")
+        return [inp], [out]
+
+    # --- directory mode -----------------------------------------------------
+    if os.path.isdir(inp):
+        if os.path.isfile(out):
+            sys.exit(
+                f"Error: input is a directory but output ({out}) is an existing file.\n"
+                "When -i is a directory, -o must be a directory."
+            )
+        try:
+            os.makedirs(out, exist_ok=True)
+        except OSError as e:
+            sys.exit(f"Error: cannot create output directory {out}: {e}")
+
+        ignore_scans = set()
+        if resume:
+            print('Resuming: skipping scans already segmented in the output directory.')
+            ignore_scans = {
+                f.split('_seg.')[0] for f in os.listdir(out) if '_seg.' in f
+            }
+
+        inp_files, out_files = [], []
+        skipped = []
+        for f in sorted(os.listdir(inp)):
+            full = os.path.join(inp, f)
+            if not os.path.isfile(full) or not is_nifti(f):
+                skipped.append(f)
+                continue
+            stem, ext = nifti_stem(f)
+            if stem in ignore_scans:
+                continue
+            inp_files.append(full)
+            out_files.append(os.path.join(out, f"{stem}_seg.{ext}"))
+
+        if skipped:
+            print(f"Note: ignoring {len(skipped)} non-NIfTI entr{'y' if len(skipped)==1 else 'ies'} "
+                  f"in the input directory: {', '.join(skipped[:5])}"
+                  + (' ...' if len(skipped) > 5 else ''))
+        if not inp_files and not resume:
+            sys.exit(f"Error: no NIfTI files (.nii / .nii.gz) found in directory: {inp}")
+        return inp_files, out_files
+
+    # --- neither ------------------------------------------------------------
+    if not os.path.exists(inp):
+        sys.exit(f"Error: input path not found: {inp}")
+    sys.exit(
+        f"Error: input must be a NIfTI file (.nii / .nii.gz) or a directory of NIfTI files (got: {inp})."
+    )
+
+
+def resolve_model_path(cli_model_path=None):
+    """
+    Resolve the model checkpoint. Priority:
+    1) --model_path CLI argument
+    2) MODEL_PATH environment variable
+    3) automatic download from the Hugging Face Hub (cached after first run)
+    """
+    if cli_model_path is not None:
+        path = Path(cli_model_path)
+        if not path.is_file():
+            sys.exit(f"Error: model checkpoint not found: {path}")
+        return path
+
+    env_model_path = os.getenv("MODEL_PATH")
+    if env_model_path:
+        path = Path(env_model_path)
+        if path.is_file():
+            return path
+        print(f"Warning: MODEL_PATH is set but does not exist ({env_model_path}); "
+              "falling back to the Hugging Face download.")
+
+    from huggingface_hub import hf_hub_download
+    try:
+        return Path(
+            hf_hub_download(repo_id=HF_REPO_ID, filename=HF_MODEL_FILENAME)
+        )
+    except Exception as e:
+        sys.exit(
+            "Error: could not download the MindGlide model weights (~123 MB) from the\n"
+            f"Hugging Face Hub ({HF_REPO_ID}). If you are offline, download the file\n"
+            f"once from https://huggingface.co/{HF_REPO_ID} and pass it with --model_path.\n"
+            f"Reason: {e}"
+        )
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        prog="mindglide",
+        description="MindGlide: brain MRI segmentation for multiple sclerosis "
+                    "(any modality, any quality). Works on GPU or CPU.",
+        epilog="Examples:\n"
+               "  mindglide -i scan.nii.gz -o scan_seg.nii.gz\n"
+               "  mindglide -i scans_dir/ -o segmentations_dir/\n"
+               "  mindglide -i scan.nii.gz -o out.nii.gz --device cpu\n",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument(
         '-i',
-        type=str, 
-        required=True, 
+        type=str,
+        required=True,
         metavar="PATH",
-        help="Path to a NIfTI file or a directory containing NIfTI images."
+        help="Path to a NIfTI file (.nii / .nii.gz) or a directory of NIfTI images."
     )
-
     parser.add_argument(
-        '-o', 
-        type=str, 
-        required=True, 
+        '-o',
+        type=str,
+        required=True,
         metavar="PATH",
-        help="Path to the output NIfTI file or directory."
+        help="Path to the output NIfTI file, or output directory when -i is a directory."
     )
-
     parser.add_argument(
-        "--model_path", 
-        type=str, 
-        default=None, 
+        "--model_path", "--model-path",
+        dest="model_path",
+        type=str,
+        default=None,
         metavar="FILE",
-        help="Path to local .pt checkpoint. If set, skips HuggingFace download."
+        help="Path to a local .pt checkpoint. If set, skips the Hugging Face download."
     )
-
     parser.add_argument(
-        '--sw_batch_size', 
-        type=int, 
-        default=4, 
-        help="Batch size for the sliding window inferer."
+        '--device',
+        choices=['auto', 'cpu', 'cuda', 'mps'],
+        default='auto',
+        help="Compute device (default: auto — picks GPU if available, else CPU)."
     )
-
     parser.add_argument(
-        '--resume', 
-        action='store_true', 
+        '--sw_batch_size', '--sw-batch-size',
+        dest='sw_batch_size',
+        type=int,
+        default=4,
+        help="Sliding-window batch size (default: 4). Lower this if you run out of GPU memory."
+    )
+    parser.add_argument(
+        '--resume',
+        action='store_true',
         help="Skip scans that have already been segmented in the output directory."
     )
-
     parser.add_argument(
-        '--no_klc', 
-        action='store_true', 
+        '--no_klc', '--no-klc',
+        dest='no_klc',
+        action='store_true',
         help="Disable 'Keep Largest Component' post-processing."
     )
-
     parser.add_argument(
-        '--no-reorient', 
-        action='store_true', 
+        '--no-reorient', '--no_reorient',
+        dest='no_reorient',
+        action='store_true',
         help=(
             "Disable automatic re-orientation to RAS coordinates before inference. "
             "Note: The final output will always be aligned with the original input "
             "scan, regardless of this setting."
         )
     )
+    parser.add_argument(
+        '--version',
+        action='version',
+        version=f"mindglide {get_version()}"
+    )
+    return parser.parse_args(argv)
 
-    args = parser.parse_args()
 
-    print("""
-If you use this tool, please cite the original MindGlide paper:
-------
-Goebl, P., Wingrove, J., Abdelmannan, O., Brito Vega, B., Stutters, 
-J., Ramos, S. D. G., ... & Eshaghi, A. (2025). 
-Enabling new insights from old scans by repurposing clinical MRI archives for multiple sclerosis research. 
-Nature Communications, 16(1), 3149.
-------
-    """)
+def main():
+    """
+    Runs the MindGlide model inference on NIfTI file(s).
+    """
+    args = parse_args()
 
-    # Load libraries only when the input is validated.
+    print(CITATION)
+
+    # Validate I/O before loading the heavy libraries so user errors fail fast.
+    inp_files, out_files = collect_io(args.i, args.o, resume=args.resume)
+
+    if len(inp_files) == 0:
+        print('Found 0 new images to segment. Exiting.')
+        return
+
+    print(f"Found {len(inp_files)} image{'s' if len(inp_files) != 1 else ''} to process.")
+
     import numpy as np
     import nibabel as nib
     import torch
     from tqdm import tqdm
-    from huggingface_hub import hf_hub_download
 
     from monai.inferers import SlidingWindowInferer
     from monai.data import Dataset, DataLoader
@@ -102,67 +318,19 @@ Nature Communications, 16(1), 3149.
     from mindglide.transforms import get_transforms, recovery_prediction, keep_largest_component
     from mindglide.consts import PATCH_SIZE, PROPERTIES
 
-    DEVICE = get_best_device()
+    DEVICE = resolve_device(args.device)
     print(f"Using device: {DEVICE}")
+    if DEVICE.type == "cpu":
+        print("Tip: CPU inference typically takes a few minutes per scan. "
+              "A CUDA GPU runs in seconds.")
 
     num_classes = len(PROPERTIES['labels'])
     as_discrete = AsDiscrete(argmax=True, to_onehot=num_classes)
-    
-
-    # ===============================================
-    # Parse I/O
-    # ===============================================
-    inp, out = args.i, args.o
-
-    def is_nifti(path):
-        return path.endswith(('.nii', '.nii.gz'))
-
-    if is_nifti(inp) and is_nifti(out):
-        inp_files = [inp]
-        out_files = [out]
-
-    elif os.path.isdir(inp):
-        os.makedirs(out, exist_ok=True)
-
-        ignore_scans = set()
-        if args.resume:
-            print('Ignoring scans already segmented.')
-            ignore_scans = {
-                f.split('_seg.')[0] for f in os.listdir(out) if '_seg.' in f
-            }
-
-        inp_files, out_files = [], []
-        for f in os.listdir(inp):
-            name, ext = f.split('.', 1)
-            if name in ignore_scans or not is_nifti(f):
-                continue
-            inp_files.append(os.path.join(inp, f))
-            out_files.append(os.path.join(out, f"{name}_seg.{ext}"))
-
-    else:
-        print("Error: invalid input/output paths.")
-        exit(1)
 
     # ===============================================
     # Download and initialise the model.
     # ===============================================
-    # Download the weights from HF / resolve checkpoint path
-    env_model_path = os.getenv("MODEL_PATH")
-
-    if env_model_path is not None and Path(env_model_path).is_file():
-        # 1) Prefer MODEL_PATH if set and exists
-        model_path = Path(env_model_path)
-    elif args.model_path is not None:
-        # 2) Then fall back to CLI argument
-        model_path = Path(args.model_path)
-    else:
-        # 3) Finally, download from HF as before
-        model_path = Path(
-            hf_hub_download(
-                repo_id="MS-PINPOINT/mindglide",
-                filename="_20240404_conjurer_trained_dice_7733.pt",
-            )
-        )
+    model_path = resolve_model_path(args.model_path)
 
     # Instantiate MindGlide network and load weights
     net = get_network(checkpoint_path=model_path, device=DEVICE)
@@ -176,23 +344,30 @@ Nature Communications, 16(1), 3149.
         mode='gaussian',
     )
 
-    if len(inp_files) == 0:
-        print('Found 0 new images to segment. Exiting.')
-        exit()
-
     # ===============================================
     # Prepare the datasets.
     # ===============================================
 
+    # Cheap preflight (header read only): report unreadable files one by one
+    # instead of crashing the whole run inside a DataLoader worker.
+    n_ok, failed = 0, []
+    readable = []
+    for f, o in zip(inp_files, out_files):
+        try:
+            nib.load(f)
+            readable.append((f, o))
+        except Exception as e:
+            failed.append(f)
+            print(f"⚠️ Skipping unreadable NIfTI file: {f}\nReason: {e}")
+
     # convert for MONAI dataset class formatting
-    data = [{'image': f, 'output': o} for f,o in zip(inp_files, out_files) ]
+    data = [{'image': f, 'output': o} for f, o in readable]
 
     # Create MONAI dataset and dataloader
     # The transforms handle preprocessing like resizing and intensity normalization
     dataset = Dataset(data=data, transform=get_transforms(no_reorient=args.no_reorient))
-    dataloader = DataLoader(dataset, batch_size=1, shuffle=False, num_workers=4)
-
-    print(f"Found {len(data)} images to process.")
+    num_workers = min(4, len(data), os.cpu_count() or 1)
+    dataloader = DataLoader(dataset, batch_size=1, shuffle=False, num_workers=num_workers)
 
     # ===============================================
     # Run the inference script
@@ -200,6 +375,7 @@ Nature Communications, 16(1), 3149.
 
     with torch.inference_mode():
         for batch in tqdm(dataloader, desc="Segmenting Images"):
+            scan_name = str(batch['image_meta_dict']['filename_or_obj'][0])
             try:
                 images = batch['image'].to(DEVICE)
                 opaths = batch['output']
@@ -209,16 +385,16 @@ Nature Communications, 16(1), 3149.
 
                 # Post-process and save each prediction in the batch
                 for idx in range(predictions.shape[0]):
-                    
+
                     # The image is re-oriented to RAS as part of our set of pre-processing.
                     # The original orientation can be recovered from the original affine matrix,
-                    # which is stored inside `image_meta_dict` (this is not affected by the 
-                    # transforms applied to the input). 
+                    # which is stored inside `image_meta_dict` (this is not affected by the
+                    # transforms applied to the input).
                     original_affine = batch['image_meta_dict']['affine'][idx].numpy()
                     original_orientation = nib.orientations.io_orientation(original_affine)
 
-                    # convert the prediction into [K, H, W, D] where K is 
-                    # the number of anatomical tissues.                 
+                    # convert the prediction into [K, H, W, D] where K is
+                    # the number of anatomical tissues.
                     pred = as_discrete(predictions[idx])
 
                     # the input scan is resampled if it's anisotropic. In this
@@ -239,14 +415,13 @@ Nature Communications, 16(1), 3149.
                     # label of the voxel at that position.
                     pred = np.argmax(pred, axis=0)
 
-                    
                     # This is still part of the recovery process to get the prediction
-                    # to the input space. Specifically, we pad the cropped prediction back 
+                    # to the input space. Specifically, we pad the cropped prediction back
                     # to the original image size.
                     pred_padded = np.zeros(original_shape, dtype=pred.dtype)
                     (h_start, w_start, d_start), (h_end, w_end, d_end) = bbox
                     pred_padded[h_start:h_end, w_start:w_end, d_start:d_end] = pred
-                    
+
                     # This is the correct affine of the segmentation (the affine of the input
                     # has been updated subject to different transformations, e.g., OrientationD).
                     current_affine = batch["output_affine"][idx]
@@ -254,7 +429,7 @@ Nature Communications, 16(1), 3149.
 
                     # Move the segmentation back to the original orientation.
                     current_orientation = nib.orientations.io_orientation(current_affine)
-                    
+
                     if not np.all(current_orientation == original_orientation):
                         back_to_orig_ornt = nib.orientations.ornt_transform(current_orientation, original_orientation)
                         nifti_img = nifti_img.as_reoriented(back_to_orig_ornt)
@@ -266,10 +441,32 @@ Nature Communications, 16(1), 3149.
 
                     # Save the output.
                     nib.save(nifti_img, opaths[idx])
+                    n_ok += 1
 
             except Exception as e:
-                print(f"⚠️ Error processing scan: {batch['image_meta_dict']['filename_or_obj'][0]}")
+                failed.append(scan_name)
+                print(f"\n⚠️ Error processing scan: {scan_name}")
                 print(f"Reason: {e}")
+                if DEVICE.type == 'cuda' and 'out of memory' in str(e).lower():
+                    print("Hint: reduce --sw_batch_size (e.g. --sw_batch_size 1) "
+                          "or run with --device cpu.")
+                if DEVICE.type == 'mps':
+                    print("Hint: some 3D operations are not supported on Apple MPS. "
+                          "Try --device cpu, or set PYTORCH_ENABLE_MPS_FALLBACK=1.")
                 continue
 
-    print("\nInference complete. Segmentations saved to:", args.o)
+    # ===============================================
+    # Summarise
+    # ===============================================
+    if failed:
+        print(f"\nFinished with errors: {n_ok} scan{'s' if n_ok != 1 else ''} segmented, "
+              f"{len(failed)} failed:")
+        for f in failed:
+            print(f"  - {f}")
+        sys.exit(1)
+
+    print(f"\nInference complete. {n_ok} segmentation{'s' if n_ok != 1 else ''} saved to: {args.o}")
+
+
+if __name__ == "__main__":
+    main()

--- a/inference/mindglide/transforms.py
+++ b/inference/mindglide/transforms.py
@@ -316,7 +316,9 @@ def keep_largest_component(segm: nib.Nifti1Image) -> nib.Nifti1Image:
     labeled, num_features = ndimage.label(seg_data > 0)
 
     if num_features == 0:
-        raise ValueError("No connected components found in segmentation.")
+        # Empty segmentation (e.g. the input was not a brain image); nothing to clean.
+        print("Warning: segmentation is empty — is the input a brain MRI?")
+        return segm
 
     # count the labels in the segmentation (skip first index which is background)
     sizes = np.bincount(labeled.ravel())[1:]

--- a/inference/mindglide/volumes.py
+++ b/inference/mindglide/volumes.py
@@ -1,12 +1,15 @@
 import argparse
-import nibabel as nb
-import numpy as np 
-import pandas as pd
-import json 
 import os
-from .consts import PROPERTIES 
+
+import nibabel as nb
+import numpy as np
+import pandas as pd
+
+from .consts import PROPERTIES
+
 
 def calculate_volumes(seg_file_path):
+    """Return {label_id: volume_mm3} for every label present in the image."""
     seg_img = nb.load(seg_file_path)
     seg_data = seg_img.get_fdata()
     voxel_volume = np.prod(seg_img.header.get_zooms())
@@ -16,13 +19,28 @@ def calculate_volumes(seg_file_path):
                count in zip(unique_labels, counts)}
 
     return volumes
+
+
+def volumes_dataframe(seg_file_path):
+    """Return a DataFrame with one row per MindGlide label and its volume in mm3."""
+    volumes = calculate_volumes(seg_file_path)
+    labels_dict = PROPERTIES["labels"]
+    labels_df = pd.DataFrame(list(labels_dict.items()), columns=[
+                             'Label_ID', 'Region_Name'])
+    labels_df['Label_ID'] = labels_df['Label_ID'].astype(int)
+    # Labels absent from the segmentation have zero volume (not NaN).
+    labels_df['Volume_mm3'] = labels_df['Label_ID'].map(volumes).fillna(0.0)
+    return labels_df
+
+
 def main():
     parser = argparse.ArgumentParser(
-        description="Calculate volumes from a label image"
+        prog="mindglide-volumes",
+        description="Calculate per-region volumes (mm3) from a MindGlide segmentation."
     )
     parser.add_argument(
         "label_file",
-        help="Path to a NIfTI label image (e.g. segmentation output)",
+        help="Path to a NIfTI label image (e.g. mindglide segmentation output)",
     )
     parser.add_argument(
         "--out-csv",
@@ -30,21 +48,18 @@ def main():
         help="Output CSV path (default: labels.csv in current directory)",
     )
 
-    
+    args = parser.parse_args()
 
-    args = parser.parse_args() 
+    if not os.path.isfile(args.label_file):
+        parser.error(f"label file not found: {args.label_file}")
 
-    label_file = args.label_file
     out_csv = os.path.abspath(args.out_csv)
     os.makedirs(os.path.dirname(out_csv) or ".", exist_ok=True)
 
-    volumes = calculate_volumes(label_file)
-    labels_dict = PROPERTIES["labels"] 
-    labels_df = pd.DataFrame(list(labels_dict.items()), columns=[
-                             'Label_ID', 'Region_Name'])
-    labels_df['Label_ID'] = labels_df['Label_ID'].astype(int)
-    labels_df['Volume'] = labels_df['Label_ID'].map(volumes)
+    labels_df = volumes_dataframe(args.label_file)
     labels_df.to_csv(out_csv, index=False)
+    print(f"Wrote volumes for {len(labels_df)} regions to: {out_csv}")
+
 
 if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,17 +4,24 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mindglide"
-version = "1.0.2"
-description = ""
+version = "1.1.0"
+description = "Ultrafast segmentation of real-world brain MRI for multiple-sclerosis patients — any modality, any quality."
 readme = "README.md"
 requires-python = ">=3.9"
+license = { text = "MIT" }
+authors = [
+    { name = "MS-PINPOINT team" },
+]
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: Medical Science Apps.",
 ]
 dependencies = [
-    "numpy == 1.*",
+    # numpy 1.x has no wheels for Python >= 3.13; MONAI itself allows numpy >=1.24,<3
+    "numpy >=1.24,<3",
     "nibabel == 5.*",
     "torch == 2.*",
     "tqdm",
@@ -23,6 +30,14 @@ dependencies = [
     "scikit-image",
     "pandas"
 ]
+
+[project.optional-dependencies]
+test = ["pytest"]
+
+[project.urls]
+Homepage = "https://github.com/MS-PINPOINT/mindGlide"
+Paper = "https://www.nature.com/articles/s41467-025-58274-8"
+Models = "https://huggingface.co/MS-PINPOINT/mindglide"
 
 [project.scripts]
 mindglide = "mindglide.infer:main"
@@ -33,3 +48,9 @@ package-dir = {"" = "inference"}
 
 [tool.setuptools.packages.find]
 where = ["inference"]
+
+[tool.pytest.ini_options]
+markers = [
+    "slow: end-to-end tests that download the model and run full inference",
+    "gpu: tests that require a CUDA GPU",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,49 @@
+import os
+import urllib.request
+
+import numpy as np
+import nibabel as nib
+import pytest
+
+# Public brain MRI used for end-to-end tests: the MNI152 (2009c asymmetric)
+# T1 template from TemplateFlow (CC0-licensed, no registration needed).
+MNI_URL = (
+    "https://templateflow.s3.amazonaws.com/tpl-MNI152NLin2009cAsym/"
+    "tpl-MNI152NLin2009cAsym_res-02_T1w.nii.gz"
+)
+
+
+@pytest.fixture(scope="session")
+def mni_t1(tmp_path_factory):
+    """Download (once per session) a public MNI152 T1 template, 2 mm resolution."""
+    cache = tmp_path_factory.mktemp("data") / "mni_t1_2mm.nii.gz"
+    urllib.request.urlretrieve(MNI_URL, cache)
+    return cache
+
+
+@pytest.fixture()
+def synthetic_brain(tmp_path):
+    """A small synthetic 'brain': a bright ellipsoid on dark background."""
+    shape = (48, 56, 40)
+    zz, yy, xx = np.meshgrid(
+        np.linspace(-1, 1, shape[0]),
+        np.linspace(-1, 1, shape[1]),
+        np.linspace(-1, 1, shape[2]),
+        indexing="ij",
+    )
+    data = ((xx ** 2 + yy ** 2 + zz ** 2) < 0.6).astype(np.float32) * 100
+    data += np.random.default_rng(0).normal(0, 1, shape).astype(np.float32)
+    path = tmp_path / "synthetic.nii.gz"
+    nib.save(nib.Nifti1Image(data, np.eye(4)), path)
+    return path
+
+
+def pytest_collection_modifyitems(config, items):
+    if os.environ.get("MINDGLIDE_RUN_SLOW"):
+        return
+    skip_slow = pytest.mark.skip(
+        reason="slow end-to-end test; set MINDGLIDE_RUN_SLOW=1 to run"
+    )
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,136 @@
+"""Unit tests for the command-line interface plumbing (fast, no model needed)."""
+import os
+
+import numpy as np
+import nibabel as nib
+import pytest
+
+from mindglide.infer import collect_io, is_nifti, nifti_stem, parse_args, resolve_model_path
+
+
+def make_nifti(path):
+    nib.save(nib.Nifti1Image(np.zeros((4, 4, 4), dtype=np.float32), np.eye(4)), path)
+
+
+class TestHelpers:
+    def test_is_nifti(self):
+        assert is_nifti("scan.nii")
+        assert is_nifti("scan.nii.gz")
+        assert is_nifti("SCAN.NII.GZ")
+        assert not is_nifti("scan.txt")
+        assert not is_nifti("scan")
+
+    def test_nifti_stem(self):
+        assert nifti_stem("sub-01_T1w.nii.gz") == ("sub-01_T1w", "nii.gz")
+        assert nifti_stem("scan.nii") == ("scan", "nii")
+        assert nifti_stem("a.b.c.nii.gz") == ("a.b.c", "nii.gz")
+
+
+class TestParseArgs:
+    def test_basic(self):
+        args = parse_args(["-i", "a.nii.gz", "-o", "b.nii.gz"])
+        assert args.i == "a.nii.gz" and args.o == "b.nii.gz"
+        assert args.device == "auto"
+
+    def test_flag_spelling_variants(self):
+        # both hyphen and underscore spellings are accepted
+        args = parse_args(["-i", "a", "-o", "b", "--sw-batch-size", "2",
+                           "--no-klc", "--no_reorient", "--model-path", "m.pt"])
+        assert args.sw_batch_size == 2
+        assert args.no_klc and args.no_reorient
+        assert args.model_path == "m.pt"
+
+
+class TestCollectIO:
+    def test_single_file(self, tmp_path):
+        inp = tmp_path / "scan.nii.gz"
+        make_nifti(inp)
+        out = tmp_path / "new_dir" / "seg.nii.gz"
+        ins, outs = collect_io(str(inp), str(out))
+        assert ins == [str(inp)] and outs == [str(out)]
+        # output parent directory is created up front
+        assert out.parent.is_dir()
+
+    def test_single_file_output_to_existing_dir(self, tmp_path):
+        inp = tmp_path / "scan.nii.gz"
+        make_nifti(inp)
+        ins, outs = collect_io(str(inp), str(tmp_path))
+        assert outs == [str(tmp_path / "scan_seg.nii.gz")]
+
+    def test_missing_input_file_errors_cleanly(self, tmp_path):
+        with pytest.raises(SystemExit) as e:
+            collect_io(str(tmp_path / "nope.nii.gz"), str(tmp_path / "o.nii.gz"))
+        assert "not found" in str(e.value)
+
+    def test_non_nifti_output_errors_cleanly(self, tmp_path):
+        inp = tmp_path / "scan.nii.gz"
+        make_nifti(inp)
+        with pytest.raises(SystemExit) as e:
+            collect_io(str(inp), str(tmp_path / "seg.txt"))
+        assert ".nii" in str(e.value)
+
+    def test_directory_mode_skips_clutter(self, tmp_path, capsys):
+        inp = tmp_path / "in"
+        inp.mkdir()
+        make_nifti(inp / "scan1.nii.gz")
+        make_nifti(inp / "scan2.nii")
+        # clutter that used to crash the old parser (no dot in the name, subdir, txt)
+        (inp / "README").write_text("hello")
+        (inp / "notes").mkdir()
+        (inp / "scan3.txt").write_text("not a scan")
+
+        out = tmp_path / "out"
+        ins, outs = collect_io(str(inp), str(out))
+        assert sorted(os.path.basename(f) for f in ins) == ["scan1.nii.gz", "scan2.nii"]
+        assert sorted(os.path.basename(f) for f in outs) == ["scan1_seg.nii.gz", "scan2_seg.nii"]
+        assert out.is_dir()
+
+    def test_directory_without_niftis_errors_cleanly(self, tmp_path):
+        inp = tmp_path / "in"
+        inp.mkdir()
+        (inp / "README").write_text("hello")
+        with pytest.raises(SystemExit) as e:
+            collect_io(str(inp), str(tmp_path / "out"))
+        assert "no NIfTI" in str(e.value)
+
+    def test_directory_input_with_file_output_errors_cleanly(self, tmp_path):
+        inp = tmp_path / "in"
+        inp.mkdir()
+        make_nifti(inp / "scan1.nii.gz")
+        out = tmp_path / "existing.nii.gz"
+        make_nifti(out)
+        with pytest.raises(SystemExit) as e:
+            collect_io(str(inp), str(out))
+        assert "directory" in str(e.value)
+
+    def test_resume_skips_existing(self, tmp_path):
+        inp = tmp_path / "in"
+        out = tmp_path / "out"
+        inp.mkdir()
+        out.mkdir()
+        make_nifti(inp / "scan1.nii.gz")
+        make_nifti(inp / "scan2.nii.gz")
+        make_nifti(out / "scan1_seg.nii.gz")
+        ins, _ = collect_io(str(inp), str(out), resume=True)
+        assert [os.path.basename(f) for f in ins] == ["scan2.nii.gz"]
+
+
+class TestResolveModelPath:
+    def test_cli_missing_file_errors_cleanly(self):
+        with pytest.raises(SystemExit) as e:
+            resolve_model_path("/does/not/exist.pt")
+        assert "not found" in str(e.value)
+
+    def test_cli_beats_env(self, tmp_path, monkeypatch):
+        cli_ckpt = tmp_path / "cli.pt"
+        env_ckpt = tmp_path / "env.pt"
+        cli_ckpt.write_bytes(b"x")
+        env_ckpt.write_bytes(b"x")
+        monkeypatch.setenv("MODEL_PATH", str(env_ckpt))
+        assert resolve_model_path(str(cli_ckpt)) == cli_ckpt
+
+    def test_env_used_when_no_cli(self, tmp_path, monkeypatch):
+        env_ckpt = tmp_path / "env.pt"
+        env_ckpt.write_bytes(b"x")
+        monkeypatch.setenv("MODEL_PATH", str(env_ckpt))
+        assert resolve_model_path(None) == env_ckpt

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,75 @@
+"""End-to-end tests: run the real CLI on public data (MNI152 template).
+
+These download the model weights (~123 MB, cached by Hugging Face Hub) and run
+full inference, so they are skipped unless MINDGLIDE_RUN_SLOW=1 is set:
+
+    MINDGLIDE_RUN_SLOW=1 pytest tests/test_e2e.py -v
+"""
+import subprocess
+import sys
+
+import numpy as np
+import nibabel as nib
+import pytest
+import torch
+
+
+def run_cli(*cli_args):
+    return subprocess.run(
+        [sys.executable, "-m", "mindglide.infer", *cli_args],
+        capture_output=True, text=True,
+    )
+
+
+def check_segmentation(seg_path, src_path, min_labels=10):
+    """The segmentation must match the source scan's grid and look like a brain."""
+    seg = nib.load(seg_path)
+    src = nib.load(src_path)
+    assert seg.shape == src.shape, "segmentation shape must match input"
+    assert np.allclose(seg.affine, src.affine, atol=1e-4), \
+        "segmentation affine must match input"
+    labels = np.unique(seg.get_fdata())
+    assert labels.max() <= 19, "labels must be within the MindGlide label set"
+    assert len(labels) >= min_labels, \
+        f"expected a rich segmentation, got only labels {labels}"
+
+
+@pytest.mark.slow
+class TestEndToEnd:
+    def test_cpu_single_file(self, mni_t1, tmp_path):
+        out = tmp_path / "seg_cpu.nii.gz"
+        result = run_cli("-i", str(mni_t1), "-o", str(out), "--device", "cpu")
+        assert result.returncode == 0, result.stdout + result.stderr
+        check_segmentation(out, mni_t1)
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="no CUDA GPU")
+    def test_gpu_single_file(self, mni_t1, tmp_path):
+        out = tmp_path / "seg_gpu.nii.gz"
+        result = run_cli("-i", str(mni_t1), "-o", str(out), "--device", "cuda")
+        assert result.returncode == 0, result.stdout + result.stderr
+        check_segmentation(out, mni_t1)
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="no CUDA GPU")
+    def test_gpu_directory_mode_with_clutter(self, mni_t1, tmp_path):
+        inp = tmp_path / "in"
+        inp.mkdir()
+        (inp / "scan1.nii.gz").write_bytes(mni_t1.read_bytes())
+        (inp / "README").write_text("clutter that must be ignored")
+        (inp / "subdir").mkdir()
+
+        out = tmp_path / "out"
+        result = run_cli("-i", str(inp), "-o", str(out))
+        assert result.returncode == 0, result.stdout + result.stderr
+        check_segmentation(out / "scan1_seg.nii.gz", mni_t1)
+
+    def test_failed_scan_exits_nonzero(self, tmp_path):
+        """A corrupt NIfTI must produce a non-zero exit code, not 'Inference complete'."""
+        bad = tmp_path / "bad.nii.gz"
+        bad.write_bytes(b"this is not a nifti file")
+        out = tmp_path / "seg.nii.gz"
+        result = run_cli("-i", str(bad), "-o", str(out), "--device", "cpu")
+        assert result.returncode != 0
+        output = result.stdout + result.stderr
+        assert "unreadable" in output and "Finished with errors" in output


### PR DESCRIPTION
Audit + hands-on test of the full first-time-user journey: fresh venv, `pip install git+…`, run on public data ([MNI152 template from TemplateFlow](https://templateflow.s3.amazonaws.com)) on both GPU (Quadro P6000) and CPU.

## Sharp edges found (all reproduced on current master, all fixed here)

1. **Directory mode crashed** (`ValueError: not enough values to unpack`) if the input dir contained any extensionless entry (a subfolder, a `README`…).
2. **A typo'd input filename** produced a deep MONAI `RuntimeError: applying transform` traceback — *after* downloading the 123 MB model. I/O is now validated up front with one-line errors.
3. **Failures were reported as success**: every scan could fail and the CLI still printed `Inference complete.` and exited 0. It now lists failed scans and exits non-zero.
4. **Broken GPU setups failed cryptically**: current `pip` torch wheels (cu12x) dropped Pascal-era GPUs; `torch.cuda.is_available()` is still True but every kernel fails, and MONAI mislabels the error as OOM (reproduced on a Quadro P6000: three "successful" runs, zero outputs). A new CUDA smoke test falls back to CPU with a clear explanation, and `--device` lets users override explicitly. The torch warning that explains this was also being hidden by the global warnings filter.
5. **`MODEL_PATH` env silently overrode the explicit `--model_path` flag**; precedence fixed, stale env path now warns.
6. **`numpy == 1.*` broke install on Python 3.13** (no 1.x wheels); relaxed to `>=1.24,<3`, which MONAI itself allows.
7. **Docker image had no ENTRYPOINT** (the README's `docker run … -i … -o …` couldn't work) and baked in `CUDA_LAUNCH_BLOCKING=1`, which severely slows GPU inference.
8. Corrupt NIfTI files crashed the DataLoader worker; now caught by a cheap header preflight and reported per file.
9. Empty segmentations raised `ValueError` in keep-largest-component; misc: `--version`, consistent hyphen/underscore flags, `-o <existing dir>` for single files, case-insensitive extensions, `mindglide-volumes` polish (0 instead of NaN, `Volume_mm3`, prints output path).

## Tests

`tests/`: 15 fast unit tests (no model download) + opt-in end-to-end tests (`MINDGLIDE_RUN_SLOW=1`) that segment the MNI152 template and verify shape/affine/label-set, on CPU and GPU. **All 19 pass locally** — GPU e2e on a Quadro P6000 (via cu118 wheels), CPU e2e in 1m18s for the 2 mm template. Outputs verified anatomically plausible (WM ≈ 626 mL, cerebellum ≈ 178 mL on the 1 mm template), including anisotropic (1×1×5 mm) and non-RAS (PIL) inputs whose outputs match the input grid exactly.

## Docs

README rewritten around a copy-pasteable quickstart (including a public sample scan for users with no data at hand), an options table, troubleshooting (old GPUs, OOM, Apple Silicon, offline use), fixed Docker/Apptainer instructions, and a dev/testing section. Also fixes a broken markdown code fence that was swallowing a whole section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)